### PR TITLE
Added historyApiFallBack middleware in gulp to stop getting 404 pages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const watch = require("gulp-watch");
 const browserSync = require("browser-sync");
 const reload = browserSync.reload;
 const shell = require("gulp-shell");
+const historyApiFallback = require('connect-history-api-fallback')
 
 gulp.task("default", ["styles", "webpack", "browser-sync"], () => {
   gulp.watch("./assets/sass/**/*", ["styles"]);
@@ -49,7 +50,10 @@ gulp.task("browser-sync", ["styles"], function() {
   // })
 
   browserSync.init({
-    server: "./public",
+    server: {
+      baseDir: "./public",
+      middleware: [historyApiFallback()]
+    },
     notify: false,
     open: true //change this to true if you want the broser to open automatically
   });


### PR DESCRIPTION
The problem is that Gulp didn't know how to handle any path apart from `/` - the homepage which defaulted to index.html which you had inside of `public`. This change tells react to route all requests to index.html which is where your React code lives and BrowserRouter takes care of which component is shown. 
Read more here: https://stackoverflow.com/questions/44178712/react-routing-not-working-while-manually-changing-url-react-router-4